### PR TITLE
✨ 自动获取订阅配置名称，修复模板读取问题

### DIFF
--- a/api/handler/default.go
+++ b/api/handler/default.go
@@ -33,7 +33,7 @@ func BuildSub(clashType model.ClashType, query validator.SubValidator, template 
 		template = query.Template
 	}
 	if strings.HasPrefix(template, "http") {
-		templateBytes, err = common.LoadSubscription(template, query.Refresh, query.UserAgent)
+		templateBytes, err = common.LoadSubscription(&template, query.Refresh, query.UserAgent)
 		if err != nil {
 			logger.Logger.Debug(
 				"load template failed", zap.String("template", template), zap.Error(err),
@@ -62,11 +62,19 @@ func BuildSub(clashType model.ClashType, query validator.SubValidator, template 
 	var proxyList []model.Proxy
 
 	for i := range query.Subs {
-		data, err := common.LoadSubscription(query.Subs[i], query.Refresh, query.UserAgent)
+		data, err := common.LoadSubscription(&query.Subs[i], query.Refresh, query.UserAgent)
 		subName := ""
 		if strings.Contains(query.Subs[i], "#") {
 			subName = query.Subs[i][strings.LastIndex(query.Subs[i], "#")+1:]
 		}
+
+		// 设置订阅名称
+		if temp.SubscriptionName == "" {
+			temp.SubscriptionName = subName
+		} else if subName != "" {
+			temp.SubscriptionName += "-" + subName
+		}
+
 		if err != nil {
 			logger.Logger.Debug(
 				"load subscription failed", zap.String("url", query.Subs[i]), zap.Error(err),

--- a/api/handler/short_link.go
+++ b/api/handler/short_link.go
@@ -88,7 +88,6 @@ func UpdateLinkHandler(c *gin.Context) {
 }
 
 func GetRawConfHandler(c *gin.Context) {
-
 	hash := c.Param("hash")
 	password := c.Query("password")
 
@@ -115,17 +114,32 @@ func GetRawConfHandler(c *gin.Context) {
 		return
 	}
 
-	response, err := http.Get("http://localhost:" + strconv.Itoa(config.Default.Port) + "/" + shortLink.Url)
+	// 创建新的请求
+	req, _ := http.NewRequest("GET", "http://localhost:"+strconv.Itoa(config.Default.Port)+"/"+shortLink.Url, nil)
+	// 设置User-Agent
+	if userAgent := c.GetHeader("User-Agent"); userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+
+	response, err := http.DefaultClient.Do(req)
 	if err != nil {
 		respondWithError(c, http.StatusInternalServerError, "请求错误: "+err.Error())
 		return
 	}
 	defer response.Body.Close()
 
+	// 读取响应体
 	all, err := io.ReadAll(response.Body)
 	if err != nil {
 		respondWithError(c, http.StatusInternalServerError, "读取错误: "+err.Error())
 		return
+	}
+
+	// 复制原始响应的header到新响应
+	for key, values := range response.Header {
+		for _, value := range values {
+			c.Header(key, value)
+		}
 	}
 
 	c.String(http.StatusOK, string(all))

--- a/common/sub.go
+++ b/common/sub.go
@@ -5,11 +5,16 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
+
+	"encoding/json"
 
 	"github.com/nitezs/sub2clash/config"
 )
@@ -17,11 +22,11 @@ import (
 var subsDir = "subs"
 var fileLock sync.RWMutex
 
-func LoadSubscription(url string, refresh bool, userAgent string) ([]byte, error) {
+func LoadSubscription(url *string, refresh bool, userAgent string) ([]byte, error) {
 	if refresh {
 		return FetchSubscriptionFromAPI(url, userAgent)
 	}
-	hash := sha256.Sum224([]byte(url))
+	hash := sha256.Sum224([]byte(*url))
 	fileName := filepath.Join(subsDir, hex.EncodeToString(hash[:]))
 	stat, err := os.Stat(fileName)
 	if err != nil {
@@ -32,6 +37,18 @@ func LoadSubscription(url string, refresh bool, userAgent string) ([]byte, error
 	}
 	lastGetTime := stat.ModTime().Unix()
 	if lastGetTime+config.Default.CacheExpire > time.Now().Unix() {
+		// 读取缓存的订阅名
+		if !strings.Contains(*url, "#") {
+			nameFile := filepath.Join(subsDir, "name.json")
+			if nameData, err := os.ReadFile(nameFile); err == nil {
+				var names map[string]string
+				if err := json.Unmarshal(nameData, &names); err == nil {
+					if name, ok := names[hex.EncodeToString(hash[:])]; ok {
+						*url = *url + "#" + name
+					}
+				}
+			}
+		}
 		file, err := os.Open(fileName)
 		if err != nil {
 			return nil, err
@@ -52,10 +69,10 @@ func LoadSubscription(url string, refresh bool, userAgent string) ([]byte, error
 	return FetchSubscriptionFromAPI(url, userAgent)
 }
 
-func FetchSubscriptionFromAPI(url string, userAgent string) ([]byte, error) {
-	hash := sha256.Sum224([]byte(url))
+func FetchSubscriptionFromAPI(url *string, userAgent string) ([]byte, error) {
+	hash := sha256.Sum224([]byte(*url))
 	fileName := filepath.Join(subsDir, hex.EncodeToString(hash[:]))
-	resp, err := Get(url, WithUserAgent(userAgent))
+	resp, err := Get(*url, WithUserAgent(userAgent))
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +99,39 @@ func FetchSubscriptionFromAPI(url string, userAgent string) ([]byte, error) {
 	_, err = file.Write(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write to sub.yaml: %w", err)
+	}
+
+	// 从响应头中获取订阅名称
+	if !strings.Contains(*url, "#") {
+		subName := ""
+		if _, params, _ := mime.ParseMediaType(resp.Header.Get("Content-Disposition")); params != nil {
+			if fn, ok := params["filename"]; ok {
+				subName = fn
+			} else if fn, ok := params["filename*"]; ok && strings.HasPrefix(fn, "UTF-8''") {
+				if decodedName, err := neturl.QueryUnescape(strings.TrimPrefix(fn, "UTF-8''")); err == nil {
+					subName = decodedName
+				}
+			}
+		}
+
+		// 保存订阅名称到 JSON 文件
+		if subName != "" {
+			nameFile := filepath.Join(subsDir, "name.json")
+			var names map[string]string
+			if nameData, err := os.ReadFile(nameFile); err == nil {
+				_ = json.Unmarshal(nameData, &names)
+			}
+			if names == nil {
+				names = make(map[string]string)
+			}
+			hash := sha256.Sum224([]byte(*url))
+			names[hex.EncodeToString(hash[:])] = subName
+			if nameData, err := json.Marshal(names); err == nil {
+				_ = os.WriteFile(nameFile, nameData, 0644)
+			}
+		}
+
+		*url = *url + "#" + subName
 	}
 	return data, nil
 }

--- a/common/template.go
+++ b/common/template.go
@@ -8,7 +8,7 @@ import (
 )
 
 func LoadTemplate(template string) ([]byte, error) {
-	tPath := filepath.Join("templates", template)
+	tPath := filepath.Join("templates", template+".yaml")
 	if _, err := os.Stat(tPath); err == nil {
 		file, err := os.Open(tPath)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -25,8 +25,8 @@ var Dev string
 
 func LoadConfig() error {
 	Default = &Config{
-		MetaTemplate:       "template_meta.yaml",
-		ClashTemplate:      "template_clash.yaml",
+		MetaTemplate:       "template_meta",
+		ClashTemplate:      "template_clash",
 		RequestRetryTimes:  3,
 		RequestMaxFileSize: 1024 * 1024 * 1,
 		Port:               8011,

--- a/model/sub.go
+++ b/model/sub.go
@@ -64,6 +64,8 @@ type Subscription struct {
 	RawTLS        TLS                       `yaml:"tls,omitempty"`
 	Listeners     []map[string]any          `yaml:"listeners,omitempty"`
 
+	SubscriptionName string `yaml:"-"`
+
 	ClashForAndroid RawClashForAndroid `yaml:"clash-for-android,omitempty" json:"clash-for-android"`
 }
 


### PR DESCRIPTION
自动从订阅链接中获取配置名称，当请求头中为clash时，在大部分订阅链接响应头中可以读取到订阅配置的名称。

修改自定义模板无法读取的问题，读取自定义订阅模板文件时不会加上yaml后缀，已修正这个问题。
