### PR TITLE
修复 GetRawConfHandler 中短链的构建问题 | Fix URL construction in GetRawConfHandler

### DIFF
--- a/server/handler/short_link.go
+++ b/server/handler/short_link.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -168,7 +169,19 @@ func GetRawConfHandler(c *gin.Context) {
 		return
 	}
 
-	response, err := http.Get("http://" + strings.TrimSuffix(config.GlobalConfig.Address, "/") + "/" + shortLink.Url)
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	host := c.Request.Host
+	targetPath := strings.TrimPrefix(shortLink.Url, "/")
+	requestURL := fmt.Sprintf("%s://%s/%s", scheme, host, targetPath)
+	
+	client := &http.Client{
+		Timeout: 30 * time.Second, // 30秒超时
+	}
+	
+	response, err := client.Get(requestURL)
 	if err != nil {
 		respondWithError(c, http.StatusInternalServerError, "请求错误: "+err.Error())
 		return


### PR DESCRIPTION
## 问题描述

问题来自 Issue #66

```
response, err := http.Get("http://" + strings.TrimSuffix(config.GlobalConfig.Address, "/") + "/" + shortLink.Url)
```

## 问题分析

原代码使用了 `0.0.0.0` 这个错误的地址（配置中的监听地址而非客户端实际访问地址）来生成短链，导致短链打不开。

## 影响范围

根据 Commit da9a172

此 Bug 影响了以下 Releases

[v0.0.13-beta.4](https://github.com/bestnite/sub2clash/releases/tag/v0.0.13-beta.4)
[v0.0.13-beta.3](https://github.com/bestnite/sub2clash/releases/tag/v0.0.13-beta.3)
[v0.0.13-beta.2](https://github.com/bestnite/sub2clash/releases/tag/v0.0.13-beta.2)
[v0.0.13-beta.1](https://github.com/bestnite/sub2clash/releases/tag/v0.0.13-beta.1)
[v0.0.12](https://github.com/bestnite/sub2clash/releases/tag/v0.0.12)
[v0.0.12-beta.3](https://github.com/bestnite/sub2clash/releases/tag/v0.0.12-beta.3)
[v0.0.12-beta.2](https://github.com/bestnite/sub2clash/releases/tag/v0.0.12-beta.2)
[v0.0.12-beta.1](https://github.com/bestnite/sub2clash/releases/tag/v0.0.12-beta.1)

## 解决方案

1. 使用请求上下文动态构建 URL
```go
scheme := "http"
if c.Request.TLS != nil {
	scheme = "https"
}
host := c.Request.Host
targetPath := strings.TrimPrefix(shortLink.Url, "/")
requestURL := fmt.Sprintf("%s://%s/%s", scheme, host, targetPath)
```

2. 添加 30 秒请求超时防止阻塞

```go
client := &http.Client{
	Timeout: 30 * time.Second, // 30秒超时
}
response, err := client.Get(requestURL)
```

